### PR TITLE
fix: make example optional in order to authorize build and merge other PRs

### DIFF
--- a/src/meta/endpoint-defs-type.ts
+++ b/src/meta/endpoint-defs-type.ts
@@ -19,7 +19,7 @@ export interface EndpointDefParamBase<TType> {
   in: 'query' | 'formData';
   type: TType;
   name: string;
-  example: unknown;
+  example?: unknown;
   required: boolean;
 }
 


### PR DESCRIPTION
I suggest to merge this PR, then 
https://github.com/gladiaio/gladia-sdk-js/pull/20 to add data_type used in the next PR to merge :
https://github.com/gladiaio/http-triton-client/pull/21

Then remove the optionnality of example in inputs